### PR TITLE
Disconnected is dispatched twice on the GamePlayer

### DIFF
--- a/src/main/java/fr/quatrevieux/araknemu/game/handler/StopSession.java
+++ b/src/main/java/fr/quatrevieux/araknemu/game/handler/StopSession.java
@@ -20,6 +20,7 @@
 package fr.quatrevieux.araknemu.game.handler;
 
 import fr.quatrevieux.araknemu.game.handler.event.Disconnected;
+import fr.quatrevieux.araknemu.game.player.PlayerSessionScope;
 import fr.quatrevieux.araknemu.network.game.GameSession;
 import fr.quatrevieux.araknemu.network.in.PacketHandler;
 import fr.quatrevieux.araknemu.network.in.SessionClosed;
@@ -33,13 +34,10 @@ import java.util.stream.Stream;
 final public class StopSession implements PacketHandler<GameSession, SessionClosed> {
     @Override
     public void handle(GameSession session, SessionClosed packet) {
-        Stream.of(session.exploration(), session.fighter(), session.player())
-            .filter(Objects::nonNull)
-            .forEach(scope -> {
-                scope.dispatch(new Disconnected());
-                scope.unregister(session);
-            })
-        ;
+        // Issue #85 : all session scopes forward "Disconnected" event to GamePlayer
+        // So, the event should be dispatched only to the first scope to prevent to be dispatched twice
+        scopes(session).findFirst().ifPresent(scope -> scope.dispatch(new Disconnected()));
+        scopes(session).forEach(scope -> scope.unregister(session));
 
         if (session.isLogged()) {
             session.account().detach();
@@ -49,5 +47,9 @@ final public class StopSession implements PacketHandler<GameSession, SessionClos
     @Override
     public Class<SessionClosed> packet() {
         return SessionClosed.class;
+    }
+
+    private Stream<PlayerSessionScope> scopes(GameSession session) {
+        return Stream.of(session.exploration(), session.fighter(), session.player()).filter(Objects::nonNull);
     }
 }

--- a/src/test/java/fr/quatrevieux/araknemu/game/handler/StopSessionTest.java
+++ b/src/test/java/fr/quatrevieux/araknemu/game/handler/StopSessionTest.java
@@ -31,12 +31,14 @@ import fr.quatrevieux.araknemu.game.fight.Fight;
 import fr.quatrevieux.araknemu.game.fight.FightBaseCase;
 import fr.quatrevieux.araknemu.game.fight.fighter.player.PlayerFighter;
 import fr.quatrevieux.araknemu.game.fight.state.PlacementState;
+import fr.quatrevieux.araknemu.game.handler.event.Disconnected;
 import fr.quatrevieux.araknemu.game.player.GamePlayer;
 import fr.quatrevieux.araknemu.network.in.SessionClosed;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -140,5 +142,17 @@ class StopSessionTest extends FightBaseCase {
         assertNull(session.fighter());
         assertFalse(fight.active());
         assertTrue(fighter.dead());
+    }
+
+    @Test
+    void dispatchDisconnectedOnlyOnce() throws SQLException, ContainerException {
+        explorationPlayer();
+
+        AtomicInteger count = new AtomicInteger();
+        gamePlayer().dispatcher().add(Disconnected.class, e -> count.incrementAndGet());
+
+        handler.handle(session, new SessionClosed());
+
+        assertEquals(1, count.get());
     }
 }


### PR DESCRIPTION
Fix #85 : The Disconnected event is dispatched on each "scopes", but exploration and fighter scopes forward the event to GamePlayer, which trigger double update queries.