### PR TITLE
test(game): :white_check_mark: add new parameter for lastLogin

### DIFF
--- a/src/main/java/fr/quatrevieux/araknemu/network/game/out/info/Information.java
+++ b/src/main/java/fr/quatrevieux/araknemu/network/game/out/info/Information.java
@@ -135,6 +135,24 @@ public final class Information extends AbstractInformationMessage {
     }
 
     /**
+     * Show the last login date and IP address
+     *
+     * @param date Last login date
+     * @param ipAddress Last login IP address
+     * @param zoneId The zone id
+     */
+    public static Information lastLogin(Instant date, String ipAddress, ZoneId zoneId) {
+        final LocalDateTime localDateTime = LocalDateTime.ofInstant(date, zoneId);
+
+        return new Information(
+            152,
+            localDateTime.getYear(), localDateTime.getMonthValue(), localDateTime.getDayOfMonth(),
+            localDateTime.getHour(), localDateTime.getMinute(),
+            ipAddress
+        );
+    }
+
+    /**
      * Show the current IP address
      *
      * @param ipAddress IP address to show

--- a/src/test/java/fr/quatrevieux/araknemu/network/game/out/info/InformationTest.java
+++ b/src/test/java/fr/quatrevieux/araknemu/network/game/out/info/InformationTest.java
@@ -23,6 +23,7 @@ import fr.quatrevieux.araknemu.data.constant.Characteristic;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.time.ZoneId;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -92,7 +93,7 @@ class InformationTest {
     void lastLogin() {
         assertEquals(
             "Im0152;2020~6~20~16~25~141.22.12.34",
-            Information.lastLogin(Instant.parse("2020-06-20T14:25:00.00Z"), "141.22.12.34").toString()
+            Information.lastLogin(Instant.parse("2020-06-20T14:25:00.00Z"), "141.22.12.34", ZoneId.of("Europe/Paris")).toString()
         );
     }
 


### PR DESCRIPTION
### Error
When I try to run the tests, I get the following error.
![image](https://github.com/Arakne/Araknemu/assets/72704457/8cb6bf72-8e6a-4f22-a945-55316810b2d2)

This error is generated because the Information.lastLogin method uses the system's default zoneId.

### Fix
To correct, the methods are overwritten, in which a parameter is passed, which refers to the zoneId
![image](https://github.com/Arakne/Araknemu/assets/72704457/e44f45cd-1242-4259-b2ab-4c60d0224176)
