### PR TITLE
feat: add a new admin command to retrieve infos of the current map

### DIFF
--- a/src/main/java/fr/quatrevieux/araknemu/game/admin/player/MapInfo.java
+++ b/src/main/java/fr/quatrevieux/araknemu/game/admin/player/MapInfo.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Araknemu.
+ *
+ * Araknemu is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Araknemu is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Araknemu.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Copyright (c) 2017-2026 Leor Finacre
+ */
+package fr.quatrevieux.araknemu.game.admin.player;
+
+import fr.quatrevieux.araknemu.common.account.Permission;
+import fr.quatrevieux.araknemu.game.admin.AbstractCommand;
+import fr.quatrevieux.araknemu.game.admin.AdminPerformer;
+import fr.quatrevieux.araknemu.game.admin.exception.AdminException;
+import fr.quatrevieux.araknemu.game.player.GamePlayer;
+
+public final class MapInfo extends AbstractCommand<Void> {
+    GamePlayer player;
+
+    public MapInfo(GamePlayer player) {
+        this.player = player;
+    }
+
+    @Override
+    protected void build(Builder builder) {
+        builder
+                .help(
+                        formatter -> formatter
+                                .description("Get info of the current map")
+                                .synopsis("mapinfo")
+                                .example("mapinfo", "Get the info of the map")
+                )
+                .requires(Permission.MANAGE_PLAYER)
+        ;
+    }
+
+    @Override
+    public String name() {
+        return "mapinfo";
+    }
+
+    @Override
+    public void execute(AdminPerformer performer, Void arguments) throws AdminException {
+        performer.success("MapID {} CellID {}", player.position().map(), player.position().cell());
+    }
+}

--- a/src/main/java/fr/quatrevieux/araknemu/game/admin/player/PlayerContext.java
+++ b/src/main/java/fr/quatrevieux/araknemu/game/admin/player/PlayerContext.java
@@ -52,6 +52,7 @@ public final class PlayerContext extends AbstractContext<PlayerContext> {
             .add(new Save(player))
             .add(new Message(player))
             .add(new Kick(player))
+            .add(new MapInfo(player))
         ;
     }
 


### PR DESCRIPTION
mapinfo retrieve map ID and cell ID where the player is currently at. Useful to debug map triggers that aren't working
<img width="1315" height="766" alt="image" src="https://github.com/user-attachments/assets/21b55aba-e592-4f22-aff0-99d600613f2f" />
